### PR TITLE
[#LIEF-9622] Make android-gallery more configurable

### DIFF
--- a/src/main/java/com/liefery/android/gallery/ActionActivity.java
+++ b/src/main/java/com/liefery/android/gallery/ActionActivity.java
@@ -50,21 +50,28 @@ public class ActionActivity extends Activity implements EasyImage.Callbacks {
         @NonNull List<File> files,
         ImageSource source,
         int type ) {
+
         if ( files.size() > 0 ) {
             File file = files.get( 0 );
+
+            Intent intent = createIntent( EVENT_SUCCESS ).putExtra(
+                "file",
+                file.getAbsolutePath() );
 
             // Samsung treatment <3
             //  - Images are not rotated properly
             //    https://github.com/jkwiecien/EasyImage/issues/43
             //  - Rotating a full resolution image may cause out of memory exceptions
             if ( source == ImageSource.CAMERA ) {
-                rotateImageIfNecessary( file );
+                try {
+                    rotateImageIfNecessary( file );
+                } catch ( IOException exception ) {
+                    intent.putExtra( "error", (Serializable) exception );
+                }
             }
 
-            Intent intent = createIntent( EVENT_SUCCESS ).putExtra(
-                "file",
-                file.getAbsolutePath() );
             setResult( RESULT_OK, intent );
+
         } else {
             setResult( RESULT_CANCELED );
         }
@@ -72,7 +79,7 @@ public class ActionActivity extends Activity implements EasyImage.Callbacks {
         finish();
     }
 
-    private void rotateImageIfNecessary( File file ) {
+    private void rotateImageIfNecessary( File file ) throws IOException {
         FileInputStream input = null;
         FileOutputStream output = null;
         int orientation;
@@ -82,19 +89,9 @@ public class ActionActivity extends Activity implements EasyImage.Callbacks {
             input = new FileInputStream( file );
             ImageHeaderParser parser = new ImageHeaderParser( input );
             orientation = parser.getOrientation();
-        } catch ( FileNotFoundException exception ) {
-            Log.w( TAG, "Tried to open image file, but was not found" );
-            return;
-        } catch ( IOException exception ) {
-            Log.w( TAG, "Failed to parse EXIF data from image file" );
-            return;
         } finally {
             if ( input != null ) {
-                try {
-                    input.close();
-                } catch ( IOException exception ) {
-                    Log.e( TAG, "Failed to close Stream", exception );
-                }
+                input.close();
             }
         }
 
@@ -137,16 +134,11 @@ public class ActionActivity extends Activity implements EasyImage.Callbacks {
             try {
                 output = new FileOutputStream( file );
                 result.compress( Bitmap.CompressFormat.JPEG, 100, output );
-            } catch ( FileNotFoundException exception ) {
-                Log.w( TAG, "Tried to open image file, but was not found" );
             } finally {
                 result.recycle();
 
                 if ( output != null ) {
-                    try {
-                        output.close();
-                    } catch ( IOException e ) {
-                    }
+                    output.close();
                 }
             }
         }
@@ -158,6 +150,7 @@ public class ActionActivity extends Activity implements EasyImage.Callbacks {
         ImageSource source,
         int type ) {
         Intent intent = createIntent( EVENT_ERROR );
+        intent.putExtra( "error", (Serializable) exception );
         setResult( RESULT_OK, intent );
         finish();
     }

--- a/src/main/java/com/liefery/android/gallery/ActionActivity.java
+++ b/src/main/java/com/liefery/android/gallery/ActionActivity.java
@@ -52,11 +52,11 @@ public class ActionActivity extends Activity implements EasyImage.Callbacks {
         int type ) {
 
         if ( files.size() > 0 ) {
+
             File file = files.get( 0 );
 
-            Intent intent = createIntent( EVENT_SUCCESS ).putExtra(
-                "file",
-                file.getAbsolutePath() );
+            IOException rotationException = null;
+            Intent intent;
 
             // Samsung treatment <3
             //  - Images are not rotated properly
@@ -66,8 +66,18 @@ public class ActionActivity extends Activity implements EasyImage.Callbacks {
                 try {
                     rotateImageIfNecessary( file );
                 } catch ( IOException exception ) {
-                    intent.putExtra( "error", (Serializable) exception );
+                    rotationException = exception;
                 }
+            }
+
+            if ( rotationException != null ) {
+                intent = createIntent( EVENT_ERROR ).putExtra(
+                    "error",
+                    (Serializable) rotationException );
+            } else {
+                intent = createIntent( EVENT_SUCCESS ).putExtra(
+                    "file",
+                    file.getAbsolutePath() );
             }
 
             setResult( RESULT_OK, intent );

--- a/src/main/java/com/liefery/android/gallery/ActionActivityResultHandler.java
+++ b/src/main/java/com/liefery/android/gallery/ActionActivityResultHandler.java
@@ -1,0 +1,53 @@
+package com.liefery.android.gallery;
+
+import android.content.Intent;
+import android.support.annotation.Nullable;
+import java.io.File;
+
+import static com.liefery.android.gallery.GalleryView.EVENT_CANCEL;
+import static com.liefery.android.gallery.GalleryView.EVENT_ERROR;
+import static com.liefery.android.gallery.GalleryView.EVENT_SUCCESS;
+
+public class ActionActivityResultHandler {
+
+    final private Intent data;
+
+    public ActionActivityResultHandler( @Nullable Intent data ) {
+        this.data = data;
+    }
+
+    public int getEvent() {
+        return data.getIntExtra( "event", -1 );
+    }
+
+    @Nullable
+    public Throwable getError() {
+        return (Throwable) data.getSerializableExtra( "error" );
+    }
+
+    @Nullable
+    public File getFile() {
+        String path = data.getStringExtra( "file" );
+
+        if ( path == null ) {
+            // Return null instead of File throwing NullPointerException
+            return null;
+        } else {
+            File file = new File( path );
+            return file;
+        }
+    }
+
+    public boolean isSuccess() {
+        return ( getEvent() == EVENT_SUCCESS );
+    }
+
+    public boolean isCanceled() {
+        return ( getEvent() == EVENT_CANCEL );
+    }
+
+    public boolean isError() {
+        return ( getEvent() == EVENT_ERROR );
+    }
+
+}

--- a/src/main/java/com/liefery/android/gallery/ActionActivityResultHandler.java
+++ b/src/main/java/com/liefery/android/gallery/ActionActivityResultHandler.java
@@ -29,13 +29,7 @@ public class ActionActivityResultHandler {
     public File getFile() {
         String path = data.getStringExtra( "file" );
 
-        if ( path == null ) {
-            // Return null instead of File throwing NullPointerException
-            return null;
-        } else {
-            File file = new File( path );
-            return file;
-        }
+        return path == null ? null : new File( path );
     }
 
     public boolean isSuccess() {

--- a/src/main/java/com/liefery/android/gallery/PhotoAuxilery.java
+++ b/src/main/java/com/liefery/android/gallery/PhotoAuxilery.java
@@ -5,8 +5,6 @@ import android.content.Intent;
 import android.support.v4.app.Fragment;
 import android.util.Log;
 
-import java.io.File;
-
 import static com.liefery.android.gallery.GalleryView.*;
 
 public class PhotoAuxilery extends Fragment {
@@ -42,25 +40,21 @@ public class PhotoAuxilery extends Fragment {
             return;
         }
 
-        int event = data.getIntExtra( "event", -1 );
+        ActionActivityResultHandler resultHandler = new ActionActivityResultHandler(
+            data );
 
-        String path;
-        File file;
+        int event = resultHandler.getEvent();
 
         switch ( event ) {
             case EVENT_SUCCESS:
-                path = data.getStringExtra( "file" );
-                file = new File( path );
-                galleryView.addPhoto( file, true );
+                galleryView.addPhoto( resultHandler.getFile(), true );
             break;
             case EVENT_CANCEL:
             break;
             case EVENT_ERROR:
             break;
             case EVENT_DELETE:
-                path = data.getStringExtra( "file" );
-                file = new File( path );
-                galleryView.removePhoto( file );
+                galleryView.removePhoto( resultHandler.getFile() );
             break;
             default:
                 Log.w( TAG, "Received unknown event code " + event );


### PR DESCRIPTION
### Two main changes:

1. **Add `ActionActivityResultHandler`:** primarily to be used by library consumers (e.g. `courier-app`), but also some in `PhotoAuxillery`.

2. **Put exceptions encountered during photo taking xor rotation into the result:** library consumer can then retrieve exception via `ActionActivityResultHandler`'s `getError` method.